### PR TITLE
chore: document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single static **Next.js 14** personal blog (App Router, `output: 'export'`) using `contentlayer` for MDX posts (`data/blog`, `posts/`), Tailwind, and Framer Motion. There is no backend/database and no test suite.
+
+### Package manager / Node
+- Use **pnpm 9.6.0** (matches CI in `.github/workflows/sync-post.yml`). It is activated via corepack; invoke as `corepack pnpm ...`. The system default `pnpm` is v10, which blocks build scripts (e.g. `sharp`) behind an interactive prompt, so prefer the corepack `pnpm@9.6.0`.
+- Node 20 or 22 both work (default VM node is 22).
+
+### Required env vars (non-obvious)
+- `env.mjs` runs Zod validation at build/dev startup and **throws** if `NEXT_PUBLIC_SITE_URL` and `NEXT_PUBLIC_SITE_EMAIL_FROM` are missing. A local `.env` with dev placeholders is required, and it is **git-ignored** (never committed), so it must exist locally. The startup update script recreates it if absent. You can bypass validation with `SKIP_ENV_VALIDATION=1`, but the two `NEXT_PUBLIC_` values are still consumed by the app, so setting them is preferred.
+
+### Commands (see `package.json` scripts)
+- Dev server: `corepack pnpm dev` (http://localhost:3000).
+- Build (static export to `out/`): `corepack pnpm build`.
+- Lint: `corepack pnpm lint` — note this script runs `eslint --fix` and **mutates files**. To only check without changing files, run `corepack pnpm exec eslint --ext .ts,.js,.jsx,.tsx .`.
+- `next build` triggers RSS generation (`scripts/generate-rss.js`) via `next.config.mjs`.
+
+### Git hooks
+- Husky runs `lint-staged` (eslint --fix + prettier) on commit and `commitlint` (conventional commits) on commit messages, so commit messages must follow the conventional format (e.g. `feat: ...`, `chore: ...`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this Next.js static blog, and adds `AGENTS.md` with durable, non-obvious setup notes for future cloud agents.

No application code was modified. The only committed change is the new `AGENTS.md`.

## Environment setup

- Package manager: **pnpm 9.6.0** via corepack (matches CI; system pnpm v10 blocks build scripts behind an interactive prompt).
- Required env vars: `env.mjs` Zod-validates `NEXT_PUBLIC_SITE_URL` and `NEXT_PUBLIC_SITE_EMAIL_FROM` at startup and throws if missing. A git-ignored `.env` with dev placeholders is created by the startup update script.

## Verification

| Step | Command | Result |
| --- | --- | --- |
| Install | `corepack pnpm install --frozen-lockfile` | OK |
| Lint | `corepack pnpm exec eslint --ext .ts,.js,.jsx,.tsx .` | Clean, no errors |
| Build | `corepack pnpm build` | Static export, 20/20 pages generated |
| Run | `corepack pnpm dev` | Dev server on :3000, all routes HTTP 200 |

Browsed the blog end-to-end (home → posts list → open article → toggle light/dark theme) to confirm core functionality works.

[blog_dev_walkthrough.mp4](https://cursor.com/agents/bc-54c1b1a5-acd3-431e-ae35-b997df15d90a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_dev_walkthrough.mp4)

[Homepage light mode](https://cursor.com/agents/bc-54c1b1a5-acd3-431e-ae35-b997df15d90a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_home_light.webp)
[Blog post dark mode](https://cursor.com/agents/bc-54c1b1a5-acd3-431e-ae35-b997df15d90a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post_dark.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54c1b1a5-acd3-431e-ae35-b997df15d90a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54c1b1a5-acd3-431e-ae35-b997df15d90a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

