### PR TITLE
Add TeamBoard and 黑根 to projects showcase

### DIFF
--- a/src/app/(app)/projects/Projects.tsx
+++ b/src/app/(app)/projects/Projects.tsx
@@ -49,6 +49,38 @@ const projects: ProjectItem[] = [
 			'Next.js + Chakra UI 搭建成可直接演示的完整前端产品'
 		],
 		tags: ['Next.js', 'Chakra UI', '交互产品', '前端']
+	},
+	{
+		id: 'teamboard',
+		code: 'TB',
+		name: 'TeamBoard',
+		url: 'https://teamboard-one.vercel.app',
+		github: 'https://github.com/willson369/teamboard',
+		description:
+			'团队实时协作白板 MVP。多人同画布编辑，基于 Yjs CRDT 自动合并冲突，配合 Presence、邀请码进房与 Postgres 持久化。',
+		highlights: [
+			'Yjs CRDT：多人同时拖拽便签也不互相覆盖',
+			'邀请码 / 链接进房，Owner / Editor / Viewer 角色分离',
+			'Awareness 呈现光标、头像与选中态，刷新后画布可恢复',
+			'Next.js + Prisma + Postgres；WS 独立部署，适配 Vercel 长连接限制'
+		],
+		tags: ['Next.js', 'Yjs', 'WebSocket', 'Postgres']
+	},
+	{
+		id: 'heigen',
+		code: 'HG',
+		name: '黑根',
+		url: 'https://willson369-refactored-potato.vercel.app',
+		github: 'https://github.com/willson369/Startup-Consultant-Heigen',
+		description:
+			'创业计划指导顾问。把模糊想法推进成经得起评委追问的商业逻辑：验证想法、梳理 BP、准备路演、模拟答辩四条工作流。',
+		highlights: [
+			'四模式顾问：验证想法 / 梳理 BP / 准备路演 / 模拟答辩',
+			'分步进度条引导：先钉死用户与问题，再谈方案与叙事',
+			'右侧项目看板沉淀目标用户、核心问题、证据与下一验证',
+			'支持会话导出与本地记录清理；可接后端持久化与联网检索'
+		],
+		tags: ['AI 顾问', '创业', '产品交互', '前端']
 	}
 ];
 

--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -95,7 +95,7 @@ export default function ProjectsPage() {
 							项目深挖
 						</h2>
 					</div>
-					<span className="font-mono text-xs text-zinc-400">3 entries</span>
+					<span className="font-mono text-xs text-zinc-400">5 entries</span>
 				</div>
 				<Projects />
 			</div>

--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -32,7 +32,7 @@ export default function ProjectsPage() {
 					{title}
 				</h1>
 				<p className="mt-6 text-base text-zinc-600 dark:text-zinc-400">
-					三个可演示项目，各自负责不同能力切片：网络协议、智能合约、产品交互。
+					精选可演示项目，覆盖 AI 应用、实时协作、链上产品与前端交互。
 					下面是深挖版；如果你想先快速扫一圈，也可以去简历作品站。
 				</p>
 			</header>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 在「项目深挖」中新增两张卡片：
  - **TeamBoard** → https://teamboard-one.vercel.app （源码 willson369/teamboard）
  - **黑根** → https://willson369-refactored-potato.vercel.app （源码 Startup-Consultant-Heigen）
- 顶部「简历作品站」横幅未改
- 深挖区计数更新为 5 entries

## Note
TeamBoard 演示站当前偶发 500，链接仍按你提供的地址挂上；稳定后即可直接演示。

## Test plan
- [ ] `/projects` 出现 TeamBoard 与 黑根
- [ ] 红笔 / Subscription NFT / 星河问卜仍在
- [ ] 简历作品站入口未变

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5978bbf-58d1-47fa-890b-6d2b7238073d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5978bbf-58d1-47fa-890b-6d2b7238073d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

